### PR TITLE
updated testing with examples that use testcontainers lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
         - "rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock"
         - "rm -fr $HOME/.gradle/caches/*/plugin-resolution/"
       before_script: 
+        - "bash vm-prep/make-fixtures.sh"
         - "cd readthedocs/code-tabs/java"
       cache: 
         directories: 

--- a/readthedocs/code-tabs/bash/AllTogetherNow.sh
+++ b/readthedocs/code-tabs/bash/AllTogetherNow.sh
@@ -2,7 +2,7 @@
 
 # step 1: upload input file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-upload --replace /home/alice/sleep.sh /home/xenon/sleep.sh
+upload --replace /home/travis/sleep.sh /home/xenon/sleep.sh
 
 # step 2: submit job and capture its job identifier
 JOBID=$(xenon scheduler slurm --location ssh://localhost:10022 --username xenon --password javagat \
@@ -14,4 +14,4 @@ wait $JOBID
 
 # step 3: download generated output file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-download --replace /home/xenon/sleep.stdout.txt /home/alice/sleep.stdout.txt
+download --replace /home/xenon/sleep.stdout.txt /home/travis/sleep.stdout.txt

--- a/readthedocs/code-tabs/bash/AllTogetherNowWrong.sh
+++ b/readthedocs/code-tabs/bash/AllTogetherNowWrong.sh
@@ -2,7 +2,7 @@
 
 # step 1: upload input file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-upload /home/alice/sleep.sh /home/xenon/sleep.sh
+upload /home/travis/sleep.sh /home/xenon/sleep.sh
 
 # step 2: submit job
 xenon scheduler slurm --location ssh://localhost:10022 --username xenon --password javagat \
@@ -10,4 +10,4 @@ submit --stdout sleep.stdout.txt bash sleep.sh 60
 
 # step 3: download generated output file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-download /home/xenon/sleep.stdout.txt /home/alice/sleep.stdout.txt
+download /home/xenon/sleep.stdout.txt /home/travis/sleep.stdout.txt

--- a/readthedocs/code-tabs/bash/CopyFileLocalToLocalAbsolutePaths.sh
+++ b/readthedocs/code-tabs/bash/CopyFileLocalToLocalAbsolutePaths.sh
@@ -1,1 +1,1 @@
-xenon filesystem file copy /home/alice/thefile.txt /home/alice/thefile.bak
+xenon filesystem file copy /home/travis/thefile.txt /home/travis/thefile.bak

--- a/readthedocs/code-tabs/bash/DirectoryListing.sh
+++ b/readthedocs/code-tabs/bash/DirectoryListing.sh
@@ -1,1 +1,1 @@
-xenon filesystem file list /home/alice/fixtures
+xenon filesystem file list /home/travis/fixtures

--- a/readthedocs/code-tabs/bash/DirectoryListingRecursive.sh
+++ b/readthedocs/code-tabs/bash/DirectoryListingRecursive.sh
@@ -1,1 +1,1 @@
-xenon filesystem file list --recursive /home/alice/fixtures
+xenon filesystem file list --recursive /home/travis/fixtures

--- a/readthedocs/code-tabs/bash/DirectoryListingShowHidden.sh
+++ b/readthedocs/code-tabs/bash/DirectoryListingShowHidden.sh
@@ -1,1 +1,1 @@
-xenon filesystem file list --hidden /home/alice/fixtures
+xenon filesystem file list --hidden /home/travis/fixtures

--- a/readthedocs/code-tabs/bash/DownloadFileSftpToLocalAbsolutePaths.sh
+++ b/readthedocs/code-tabs/bash/DownloadFileSftpToLocalAbsolutePaths.sh
@@ -1,3 +1,3 @@
 # step 3: download generated output file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-download /home/xenon/sleep.stdout.txt /home/alice/sleep.stdout.txt
+download /home/xenon/sleep.stdout.txt /home/travis/sleep.stdout.txt

--- a/readthedocs/code-tabs/bash/UploadFileLocalToSftpAbsolutePaths.sh
+++ b/readthedocs/code-tabs/bash/UploadFileLocalToSftpAbsolutePaths.sh
@@ -1,3 +1,3 @@
 # step 1: upload input file(s)
 xenon filesystem sftp --location localhost:10022 --username xenon --password javagat \
-upload /home/alice/sleep.sh /home/xenon/sleep.sh
+upload /home/travis/sleep.sh /home/xenon/sleep.sh

--- a/readthedocs/code-tabs/java/build.gradle
+++ b/readthedocs/code-tabs/java/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'nl.esciencecenter.xenon:xenon:3.0.1'
     implementation 'nl.esciencecenter.xenon.adaptors:xenon-adaptors-cloud:3.0.1'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.testcontainers:testcontainers:1.11.3'
 }
 
 eclipse {

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
@@ -18,12 +18,13 @@ public class AllTogetherNow {
 
         String host = "localhost";
         String port = "10022";
-        Map<String, String> properties = null;
+        Map<String, String> propertiesSsh = null;
+        Map<String, String> propertiesSftp = null;
 
-        main(host, port, properties);
+        main(host, port, propertiesSsh, propertiesSftp);
     }
 
-    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+    public static void main(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
 
         /*
          * step 1: upload input file(s)
@@ -40,9 +41,9 @@ public class AllTogetherNow {
 
         // create the remote filesystem representation and specify the executable's path
         String fileAdaptorRemote = "sftp";
-        String filesystemRemoteLocation = "localhost:10022";
+        String filesystemRemoteLocation = host + ":" + port;
         FileSystem filesystemRemote = FileSystem.create(fileAdaptorRemote,
-                filesystemRemoteLocation, credential);
+                filesystemRemoteLocation, credential, propertiesSftp);
 
         // when waiting for jobs or copy operations to complete, wait indefinitely
         final long WAIT_INDEFINITELY = 0;
@@ -79,8 +80,8 @@ public class AllTogetherNow {
 
         // create the SLURM scheduler representation
         String schedulerAdaptor = "slurm";
-        String schedulerLocation = "ssh://localhost:10022";
-        Scheduler scheduler = Scheduler.create(schedulerAdaptor, schedulerLocation, credential);
+        String schedulerLocation = "ssh://" + host + ":" + port;
+        Scheduler scheduler = Scheduler.create(schedulerAdaptor, schedulerLocation, credential, propertiesSsh);
 
         // compose the job description:
         JobDescription jobDescription = new JobDescription();

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
@@ -55,7 +55,7 @@ public class AllTogetherNow {
             boolean recursive = false;
 
             // specify the path of the script file on the local and on the remote
-            Path fileLocal = new Path("/home/alice/sleep.sh");
+            Path fileLocal = new Path("/home/travis/sleep.sh");
             Path fileRemote = new Path("/home/xenon/sleep.sh");
 
             // start the copy operation
@@ -112,7 +112,7 @@ public class AllTogetherNow {
 
             // specify the path of the stdout file on the remote and on the local machine
             Path fileRemote = new Path("/home/xenon/sleep.stdout.txt");
-            Path fileLocal = new Path("/home/alice/sleep.stdout.txt");
+            Path fileLocal = new Path("/home/travis/sleep.stdout.txt");
 
             // start the copy operation
             String copyId = filesystemRemote.copy(fileRemote, filesystemLocal, fileLocal, copyMode, recursive);

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
@@ -1,5 +1,8 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
+import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.filesystems.CopyMode;
 import nl.esciencecenter.xenon.filesystems.CopyStatus;
@@ -11,7 +14,16 @@ import nl.esciencecenter.xenon.schedulers.Scheduler;
 
 public class AllTogetherNow {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws XenonException {
+
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> properties = null;
+
+        main(host, port, properties);
+    }
+
+    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
 
         /*
          * step 1: upload input file(s)

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNow.java
@@ -21,10 +21,10 @@ public class AllTogetherNow {
         Map<String, String> propertiesSsh = null;
         Map<String, String> propertiesSftp = null;
 
-        main(host, port, propertiesSsh, propertiesSftp);
+        runExample(host, port, propertiesSsh, propertiesSftp);
     }
 
-    public static void main(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
 
         /*
          * step 1: upload input file(s)

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
@@ -1,5 +1,8 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
+import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.filesystems.CopyMode;
 import nl.esciencecenter.xenon.filesystems.FileSystem;
@@ -9,7 +12,17 @@ import nl.esciencecenter.xenon.schedulers.Scheduler;
 
 public class AllTogetherNowWrong {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws XenonException {
+
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> propertiesSsh = null;
+        Map<String, String> propertiesSftp = null;
+
+        main(host, port, propertiesSsh, propertiesSftp);
+    }
+
+    public static void main(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
 
         /*
          * step 1: upload input file(s)
@@ -26,9 +39,9 @@ public class AllTogetherNowWrong {
 
         // create the remote filesystem representation and specify the executable's path
         String fileAdaptorRemote = "sftp";
-        String filesystemRemoteLocation = "localhost:10022";
+        String filesystemRemoteLocation = host + ":" + port;
         FileSystem filesystemRemote = FileSystem.create(fileAdaptorRemote,
-                filesystemRemoteLocation, credential);
+                filesystemRemoteLocation, credential, propertiesSftp);
 
         {
             // specify the behavior in case the target path exists already
@@ -54,8 +67,8 @@ public class AllTogetherNowWrong {
 
         // create the SLURM scheduler representation
         String schedulerAdaptor = "slurm";
-        String schedulerLocation = "ssh://localhost:10022";
-        Scheduler scheduler = Scheduler.create(schedulerAdaptor, schedulerLocation, credential);
+        String schedulerLocation = "ssh://" + host + ":" + port;
+        Scheduler scheduler = Scheduler.create(schedulerAdaptor, schedulerLocation, credential, propertiesSsh);
 
         // compose the job description:
         JobDescription jobDescription = new JobDescription();

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
@@ -38,7 +38,7 @@ public class AllTogetherNowWrong {
             boolean recursive = false;
 
             // specify the path of the script file on the local and on the remote
-            Path fileLocal = new Path("/home/alice/sleep.sh");
+            Path fileLocal = new Path("/home/travis/sleep.sh");
             Path fileRemote = new Path("/home/xenon/sleep.sh");
 
             // start the copy operation
@@ -79,7 +79,7 @@ public class AllTogetherNowWrong {
 
             // specify the path of the stdout file on the remote and on the local machine
             Path fileRemote = new Path("/home/xenon/sleep.stdout.txt");
-            Path fileLocal = new Path("/home/alice/sleep.stdout.txt");
+            Path fileLocal = new Path("/home/travis/sleep.stdout.txt");
 
             // start the copy operation
             filesystemRemote.copy(fileRemote, filesystemLocal, fileLocal, copyMode, recursive);

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrong.java
@@ -19,10 +19,10 @@ public class AllTogetherNowWrong {
         Map<String, String> propertiesSsh = null;
         Map<String, String> propertiesSftp = null;
 
-        main(host, port, propertiesSsh, propertiesSftp);
+        runExample(host, port, propertiesSsh, propertiesSftp);
     }
 
-    public static void main(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> propertiesSsh, Map<String, String> propertiesSftp) throws XenonException {
 
         /*
          * step 1: upload input file(s)

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/CopyFileLocalToLocalAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/CopyFileLocalToLocalAbsolutePaths.java
@@ -14,8 +14,8 @@ public class CopyFileLocalToLocalAbsolutePaths {
         FileSystem filesystem = FileSystem.create(adaptor);
 
         // create Paths for the source and destination files, using absolute paths
-        Path sourceFile = new Path("/home/alice/thefile.txt");
-        Path destFile = new Path("/home/alice/thefile.bak");
+        Path sourceFile = new Path("/home/travis/thefile.txt");
+        Path destFile = new Path("/home/travis/thefile.bak");
 
         // create the destination file only if the destination path doesn't exist yet
         CopyMode mode = CopyMode.CREATE;

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListing.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListing.java
@@ -11,7 +11,7 @@ public class DirectoryListing {
 
         String adaptor = "file";
         FileSystem filesystem = FileSystem.create(adaptor);
-        Path directory = new Path("/home/alice/fixtures");
+        Path directory = new Path("/home/travis/fixtures");
         Boolean recursive = false;
         Iterable<PathAttributes> listing = filesystem.list(directory, recursive);
 

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListingRecursive.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListingRecursive.java
@@ -11,7 +11,7 @@ public class DirectoryListingRecursive {
         String adaptor = "file";
         FileSystem filesystem = FileSystem.create(adaptor);
 
-        Path dir = new Path("/home/alice/fixtures");
+        Path dir = new Path("/home/travis/fixtures");
         boolean recursive = true;
 
         Iterable<PathAttributes> listing = filesystem.list(dir, recursive);

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListingShowHidden.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DirectoryListingShowHidden.java
@@ -11,7 +11,7 @@ public class DirectoryListingShowHidden {
         String adaptor = "file";
         FileSystem filesystem = FileSystem.create(adaptor);
 
-        Path dir = new Path("/home/alice/fixtures");
+        Path dir = new Path("/home/travis/fixtures");
         boolean recursive = false;
 
         Iterable<PathAttributes> listing = filesystem.list(dir, recursive);

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
@@ -27,7 +27,7 @@ public class DownloadFileSftpToLocalAbsolutePaths {
         FileSystem filesystemLocal = FileSystem.create(adaptorLocal);
 
         // define what file to download to
-        Path fileLocal = new Path("/home/alice/sleep.stdout.txt");
+        Path fileLocal = new Path("/home/travis/sleep.stdout.txt");
 
         // create the destination file only if the destination path doesn't exist yet
         CopyMode mode = CopyMode.CREATE;

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
@@ -1,5 +1,8 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
+import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.filesystems.CopyMode;
 import nl.esciencecenter.xenon.filesystems.CopyStatus;
@@ -8,16 +11,26 @@ import nl.esciencecenter.xenon.filesystems.Path;
 
 public class DownloadFileSftpToLocalAbsolutePaths {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws XenonException {
+
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> properties = null;
+
+        main(host, port, properties);
+    }
+
+    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+
 
         // use the sftp file system adaptor to create a file system representation; the remote
         // filesystem requires credentials to log in, so we'll have to create those too.
         String adaptorRemote = "sftp";
-        String location = "localhost:10022";
+        String location = host + ":" + port;
         String username = "xenon";
         char[] password = "javagat".toCharArray();
         PasswordCredential credential = new PasswordCredential(username, password);
-        FileSystem filesystemRemote = FileSystem.create(adaptorRemote, location, credential);
+        FileSystem filesystemRemote = FileSystem.create(adaptorRemote, location, credential, properties);
 
         // define which file to download
         Path fileRemote = new Path("/home/xenon/sleep.stdout.txt");

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePaths.java
@@ -17,10 +17,10 @@ public class DownloadFileSftpToLocalAbsolutePaths {
         String port = "10022";
         Map<String, String> properties = null;
 
-        main(host, port, properties);
+        runExample(host, port, properties);
     }
 
-    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> properties) throws XenonException {
 
 
         // use the sftp file system adaptor to create a file system representation; the remote

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetter.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetter.java
@@ -14,10 +14,10 @@ public class SlurmJobListGetter {
         String port = "10022";
         Map<String, String> properties = null;
 
-        main(host, port, properties);
+        runExample(host, port, properties);
     }
 
-    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> properties) throws XenonException {
 
 
         String adaptor = "slurm";

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetter.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetter.java
@@ -1,14 +1,27 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
+import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.schedulers.Scheduler;
 
 public class SlurmJobListGetter {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws XenonException {
+
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> properties = null;
+
+        main(host, port, properties);
+    }
+
+    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+
 
         String adaptor = "slurm";
-        String location = "ssh://localhost:10022";
+        String location = "ssh://" + host + ":" + port;
 
         // make the password credential for user 'xenon'
         String username = "xenon";
@@ -16,7 +29,7 @@ public class SlurmJobListGetter {
         PasswordCredential credential = new PasswordCredential(username, password);
 
         // create the SLURM scheduler
-        Scheduler scheduler = Scheduler.create(adaptor, location, credential);
+        Scheduler scheduler = Scheduler.create(adaptor, location, credential, properties);
 
         // ask SLURM for its queues and list the jobs in each
         for (String queueName : scheduler.getQueueNames()) {

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetter.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetter.java
@@ -16,10 +16,10 @@ public class SlurmQueuesGetter {
         String port = "10022";
         Map<String, String> properties = null;
 
-        main(host, port, properties);
+        runExample(host, port, properties);
     }
 
-    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> properties) throws XenonException {
 
         String adaptor = "slurm";
         String location = "ssh://" + host + ":" + port;

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetter.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetter.java
@@ -1,23 +1,36 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
 import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.Credential;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.schedulers.Scheduler;
 
 public class SlurmQueuesGetter {
+
+
     public static void main(String[] args) throws XenonException {
 
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> properties = null;
+
+        main(host, port, properties);
+    }
+
+    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+
         String adaptor = "slurm";
-        String location = "ssh://localhost:10022";
+        String location = "ssh://" + host + ":" + port;
 
         // make the password credential for user 'xenon'
         String username = "xenon";
-        String password = "javagat";
+        char[] password = "javagat".toCharArray();
         Credential credential = new PasswordCredential(username, password);
 
         // create the SLURM scheduler
-        try (Scheduler scheduler = Scheduler.create(adaptor, location, credential)) {
+        try (Scheduler scheduler = Scheduler.create(adaptor, location, credential, properties)) {
             // ask SLURM for its queues
             System.out.println("Available queues (starred queue is default):");
             for (String queueName : scheduler.getQueueNames()) {
@@ -30,3 +43,6 @@ public class SlurmQueuesGetter {
         }
     }
 }
+
+
+

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
@@ -15,7 +15,7 @@ public class UploadFileLocalToSftpAbsolutePaths {
         FileSystem filesystemLocal = FileSystem.create(adaptorLocal);
 
         // define what file to upload
-        Path fileLocal = new Path("/home/alice/sleep.sh");
+        Path fileLocal = new Path("/home/travis/sleep.sh");
 
         // use the sftp file system adaptor to create a file system representation; the remote
         // filesystem requires credentials to log in, so we'll have to create those too.

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
@@ -1,5 +1,8 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.Map;
+
+import nl.esciencecenter.xenon.XenonException;
 import nl.esciencecenter.xenon.credentials.PasswordCredential;
 import nl.esciencecenter.xenon.filesystems.CopyMode;
 import nl.esciencecenter.xenon.filesystems.CopyStatus;
@@ -8,7 +11,17 @@ import nl.esciencecenter.xenon.filesystems.Path;
 
 public class UploadFileLocalToSftpAbsolutePaths {
 
-    public static void main(String[] args) throws Exception {
+
+    public static void main(String[] args) throws XenonException {
+
+        String host = "localhost";
+        String port = "10022";
+        Map<String, String> properties = null;
+
+        main(host, port, properties);
+    }
+
+    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
 
         // use the local file system adaptor to create a file system representation
         String adaptorLocal = "file";
@@ -20,11 +33,11 @@ public class UploadFileLocalToSftpAbsolutePaths {
         // use the sftp file system adaptor to create a file system representation; the remote
         // filesystem requires credentials to log in, so we'll have to create those too.
         String adaptorRemote = "sftp";
-        String location = "localhost:10022";
+        String location = host + ":" + port;
         String username = "xenon";
         char[] password = "javagat".toCharArray();
         PasswordCredential credential = new PasswordCredential(username, password);
-        FileSystem filesystemRemote = FileSystem.create(adaptorRemote, location, credential);
+        FileSystem filesystemRemote = FileSystem.create(adaptorRemote, location, credential, properties);
 
         // define which file to upload to
         Path fileRemote = new Path("/home/xenon/sleep.sh");

--- a/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
+++ b/readthedocs/code-tabs/java/src/main/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePaths.java
@@ -18,10 +18,10 @@ public class UploadFileLocalToSftpAbsolutePaths {
         String port = "10022";
         Map<String, String> properties = null;
 
-        main(host, port, properties);
+        runExample(host, port, properties);
     }
 
-    public static void main(String host, String port, Map<String, String> properties) throws XenonException {
+    public static void runExample(String host, String port, Map<String, String> properties) throws XenonException {
 
         // use the local file system adaptor to create a file system representation
         String adaptorLocal = "file";

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
@@ -36,7 +36,7 @@ public class AllTogetherNowTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        AllTogetherNow.main(host, port, propertiesSsh, propertiesSftp);
+        AllTogetherNow.runExample(host, port, propertiesSsh, propertiesSftp);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
@@ -1,13 +1,35 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 
 public class AllTogetherNowTest {
 
+    private String host;
+    private String port;
+    private Map<String, String> properties;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+        properties = new HashMap<String, String>();
+        properties.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
+        properties.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+    }
+
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        AllTogetherNow.main(null);
+        AllTogetherNow.main(host, port, properties);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowTest.java
@@ -13,7 +13,8 @@ public class AllTogetherNowTest {
 
     private String host;
     private String port;
-    private Map<String, String> properties;
+    private Map<String, String> propertiesSsh;
+    private Map<String, String> propertiesSftp;
 
     @Rule
     public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
@@ -22,14 +23,20 @@ public class AllTogetherNowTest {
     public void setUp() {
         host = slurm.getContainerIpAddress();
         port = Integer.toString(slurm.getFirstMappedPort());
-        properties = new HashMap<String, String>();
-        properties.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
-        properties.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+
+        propertiesSsh = new HashMap<String, String>();
+        propertiesSsh.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
+        propertiesSsh.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+
+        propertiesSftp = new HashMap<String, String>();
+        propertiesSftp.put("xenon.adaptors.filesystems.sftp.loadSshConfig", "false");
+        propertiesSftp.put("xenon.adaptors.filesystems.sftp.loadKnownHosts", "false");
+
     }
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        AllTogetherNow.main(host, port, properties);
+        AllTogetherNow.main(host, port, propertiesSsh, propertiesSftp);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrongTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrongTest.java
@@ -1,13 +1,42 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 
 public class AllTogetherNowWrongTest {
 
+    private String host;
+    private String port;
+    private Map<String, String> propertiesSsh;
+    private Map<String, String> propertiesSftp;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+
+        propertiesSsh = new HashMap<String, String>();
+        propertiesSsh.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
+        propertiesSsh.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+
+        propertiesSftp = new HashMap<String, String>();
+        propertiesSftp.put("xenon.adaptors.filesystems.sftp.loadSshConfig", "false");
+        propertiesSftp.put("xenon.adaptors.filesystems.sftp.loadKnownHosts", "false");
+
+    }
+
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        AllTogetherNowWrong.main(null);
+        AllTogetherNowWrong.main(host, port, propertiesSsh, propertiesSftp);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrongTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/AllTogetherNowWrongTest.java
@@ -36,7 +36,7 @@ public class AllTogetherNowWrongTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        AllTogetherNowWrong.main(host, port, propertiesSsh, propertiesSftp);
+        AllTogetherNowWrong.runExample(host, port, propertiesSsh, propertiesSftp);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePathsTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePathsTest.java
@@ -1,13 +1,40 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 
 public class DownloadFileSftpToLocalAbsolutePathsTest {
 
-    @Test(expected = Test.None.class)
-    public void test1() throws Exception {
-        DownloadFileSftpToLocalAbsolutePaths.main(null);
+    private String host;
+    private String port;
+    private Map<String, String> properties;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() throws UnsupportedOperationException, IOException, InterruptedException {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+
+        // test tries to download this file, so we need to make it first
+        slurm.execInContainer("touch", "/home/xenon/sleep.stdout.txt");
+
+        properties = new HashMap<String, String>();
+        properties.put("xenon.adaptors.filesystems.sftp.loadSshConfig", "false");
+        properties.put("xenon.adaptors.filesystems.sftp.loadKnownHosts", "false");
+
     }
 
+    @Test(expected = Test.None.class)
+    public void test1() throws Exception {
+        DownloadFileSftpToLocalAbsolutePaths.main(host, port, properties);
+    }
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePathsTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/DownloadFileSftpToLocalAbsolutePathsTest.java
@@ -35,6 +35,6 @@ public class DownloadFileSftpToLocalAbsolutePathsTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        DownloadFileSftpToLocalAbsolutePaths.main(host, port, properties);
+        DownloadFileSftpToLocalAbsolutePaths.runExample(host, port, properties);
     }
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetterTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetterTest.java
@@ -29,7 +29,7 @@ public class SlurmJobListGetterTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        SlurmJobListGetter.main(host, port, properties);
+        SlurmJobListGetter.runExample(host, port, properties);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetterTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmJobListGetterTest.java
@@ -1,13 +1,35 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 
 public class SlurmJobListGetterTest {
 
+    private String host;
+    private String port;
+    private Map<String, String> properties;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+        properties = new HashMap<String, String>();
+        properties.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
+        properties.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+    }
+
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        SlurmJobListGetter.main(null);
+        SlurmJobListGetter.main(host, port, properties);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetterTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetterTest.java
@@ -1,13 +1,36 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
 
 
 public class SlurmQueuesGetterTest {
 
+    private String host;
+    private String port;
+    private Map<String, String> properties;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+        properties = new HashMap<String, String>();
+        properties.put("xenon.adaptors.schedulers.ssh.loadSshConfig", "false");
+        properties.put("xenon.adaptors.schedulers.ssh.loadKnownHosts", "false");
+    }
+
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        SlurmQueuesGetter.main(null);
+        SlurmQueuesGetter.main(host, port, properties);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetterTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/SlurmQueuesGetterTest.java
@@ -30,7 +30,7 @@ public class SlurmQueuesGetterTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        SlurmQueuesGetter.main(host, port, properties);
+        SlurmQueuesGetter.runExample(host, port, properties);
     }
 
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePathsTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePathsTest.java
@@ -30,6 +30,6 @@ public class UploadFileLocalToSftpAbsolutePathsTest {
 
     @Test(expected = Test.None.class)
     public void test1() throws Exception {
-        UploadFileLocalToSftpAbsolutePaths.main(host, port, properties);
+        UploadFileLocalToSftpAbsolutePaths.runExample(host, port, properties);
     }
 }

--- a/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePathsTest.java
+++ b/readthedocs/code-tabs/java/src/test/java/nl/esciencecenter/xenon/tutorial/UploadFileLocalToSftpAbsolutePathsTest.java
@@ -1,13 +1,35 @@
 package nl.esciencecenter.xenon.tutorial;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 
 public class UploadFileLocalToSftpAbsolutePathsTest {
 
-    @Test(expected = Test.None.class)
-    public void test1() throws Exception {
-        UploadFileLocalToSftpAbsolutePaths.main(null);
+    private String host;
+    private String port;
+    private Map<String, String> properties;
+
+    @Rule
+    public GenericContainer<?> slurm = new GenericContainer<>("nlesc/xenon-slurm:17").withExposedPorts(22);
+
+    @Before
+    public void setUp() {
+        host = slurm.getContainerIpAddress();
+        port = Integer.toString(slurm.getFirstMappedPort());
+
+        properties = new HashMap<String, String>();
+        properties.put("xenon.adaptors.filesystems.sftp.loadSshConfig", "false");
+        properties.put("xenon.adaptors.filesystems.sftp.loadKnownHosts", "false");
     }
 
+    @Test(expected = Test.None.class)
+    public void test1() throws Exception {
+        UploadFileLocalToSftpAbsolutePaths.main(host, port, properties);
+    }
 }

--- a/readthedocs/code-tabs/python/directory_listing.py
+++ b/readthedocs/code-tabs/python/directory_listing.py
@@ -4,7 +4,7 @@ from xenon import Path, FileSystem
 xenon.init()
 
 filesystem = FileSystem.create(adaptor='file')
-path = Path("/home/alice/fixtures")
+path = Path("/home/travis/fixtures")
 
 listing = filesystem.list(path, recursive=False)
 

--- a/readthedocs/tutorial.rst
+++ b/readthedocs/tutorial.rst
@@ -20,7 +20,7 @@ __ https://drive.google.com/open?id=0B1GaxSkd5lU8UkF6V1A1VGpPZ2c
 
 During the import, you'll see an initialization wizard. Make sure that the virtual machine is configured with two CPUs.
 
-Start the virtual machine and log in as user ``alice`` with password ``password``.
+Start the virtual machine and log in as user ``travis`` with password ``password``.
 
 Once the system has booted, Click ``Activities`` and then start both a terminal and Firefox by clicking their respective
 icons. Use Firefox to navigate to the tutorial text at `<https://xenon-tutorial.readthedocs.io>`_.
@@ -74,7 +74,7 @@ written in Java and Python, as a separate tab.
 
 __ https://github.com/xenon-middleware/xenon-grpc
 
-Let's try listing the contents of ``/home/alice/fixtures/``.
+Let's try listing the contents of ``/home/travis/fixtures/``.
 
 .. tabs::
 
@@ -132,7 +132,7 @@ Now let's create a file and try to use ``xenon`` to copy it:
 
 .. code-block:: bash
 
-      cd /home/alice
+      cd /home/travis
       echo 'some content' > thefile.txt
 
 Check the relevant help

--- a/vm-prep/README.md
+++ b/vm-prep/README.md
@@ -9,7 +9,7 @@
 1. Configure the VM with at least 2 CPUs.
 1. Configure main memory to use 4 GB.
 1. Configure video memory to use the maximum of 128 MB.
-1. Call the user ``alice``
+1. Call the user ``travis``
 1. Set her password to ``password``
 1. Enable Bash completion from history
 
@@ -140,12 +140,12 @@
 1. Create filesystem fixtures
 
     ```
-    mkdir /home/alice/fixtures/dir1
-    mkdir /home/alice/fixtures/.dir2
-    echo 'dir1/file1.txt' > /home/alice/fixtures/dir1/file1.txt
-    echo 'dir1/.file2.txt' > /home/alice/fixtures/dir1/.file2.txt
-    echo '.dir2/file3.txt' > /home/alice/fixtures/.dir2/file3.txt
-    echo '.dir2/.file4.txt' > /home/alice/fixtures/.dir2/.file4.txt
+    mkdir -p /home/travis/fixtures/dir1
+    mkdir -p /home/travis/fixtures/.dir2
+    echo 'dir1/file1.txt' > /home/travis/fixtures/dir1/file1.txt
+    echo 'dir1/.file2.txt' > /home/travis/fixtures/dir1/.file2.txt
+    echo '.dir2/file3.txt' > /home/travis/fixtures/.dir2/file3.txt
+    echo '.dir2/.file4.txt' > /home/travis/fixtures/.dir2/.file4.txt
     ```
 
 1. Install ``tree``

--- a/vm-prep/make-fixtures.sh
+++ b/vm-prep/make-fixtures.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# files and directories for making directory listings
+mkdir -p /home/travis/fixtures/dir1
+mkdir -p /home/travis/fixtures/.dir2
+echo 'dir1/file1.txt' > /home/travis/fixtures/dir1/file1.txt
+echo 'dir1/.file2.txt' > /home/travis/fixtures/dir1/.file2.txt
+echo '.dir2/file3.txt' > /home/travis/fixtures/.dir2/file3.txt
+echo '.dir2/.file4.txt' > /home/travis/fixtures/.dir2/.file4.txt
+
+# file for copying locally
+echo 'some content' > /home/travis/thefile.txt
+
+# sleep script
+echo '#!/usr/bin/env bash' > /home/travis/sleep.sh
+echo 'echo `date`: went to bed' >> /home/travis/sleep.sh
+echo 'sleep $1' >> /home/travis/sleep.sh
+echo 'echo `date`: woke up' >> /home/travis/sleep.sh


### PR DESCRIPTION
The approach in this PR works 

- for when i start a slurm container myself as per the tutorial text and then do a

    ```
    ./gradlew run -Pmain=nl.esciencecenter.xenon.tutorial.SlurmQueuesGetter
    ```

    in ``/readthedocs/code-tabs/java`` 

- for when I run ``nl.esciencecenter.xenon.tutorial.SlurmQueuesGetterTest`` as a JUnit test from within Eclipse
- on Travis

I guess I'm a little disappointed that the example is no longer as simple as it can be. Let's discuss next week @jmaassen @sverhoeven which way we want to go.
